### PR TITLE
Fix copy/paste typo -- default branch is 'master'

### DIFF
--- a/.github/workflows/python-publish-pypi.yaml
+++ b/.github/workflows/python-publish-pypi.yaml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 on:
   push:
     branches:
-      - main
+      - master
   release:
     types:
       - published


### PR DESCRIPTION
Follow up to https://github.com/BruDriguezz/ao3.py/pull/2, fixing a typo